### PR TITLE
fix: resolve resource loading and xmake deployment issues

### DIFF
--- a/Source/Platform/Mac/Private/MacFile.mm
+++ b/Source/Platform/Mac/Private/MacFile.mm
@@ -10,15 +10,21 @@
 namespace ChozoUtils::File {
 
 std::filesystem::path GetExecutablePath() {
+    std::filesystem::path result;
     char buffer[1024];
     uint32_t size = sizeof(buffer);
-    if (_NSGetExecutablePath(buffer, &size) == 0)
-        return std::filesystem::path(buffer).lexically_normal();
+    if (_NSGetExecutablePath(buffer, &size) == 0) {
+        result = std::filesystem::path(buffer).lexically_normal();
+    }
     else {
         std::string path(size, '\0');
         _NSGetExecutablePath(path.data(), &size);
-        return std::filesystem::path(path).lexically_normal();
+        result = std::filesystem::path(path).lexically_normal();
     }
+
+    std::filesystem::current_path(result.parent_path());
+    
+    return result;
 }
 
 // 1000-1999: System Folders (Desktop, Documents, etc..)

--- a/Source/Runtime/Engine/Private/Application.cpp
+++ b/Source/Runtime/Engine/Private/Application.cpp
@@ -40,7 +40,8 @@ void CApplication::Init(const std::string& name) {
 #endif
 
         // Setup VFS
-        std::filesystem::path projectRoot = ChozoUtils::File::GetProjectRoot();
+        std::filesystem::path projectRoot =
+            std::filesystem::absolute(ChozoUtils::File::GetExecutablePath()).parent_path();
         CZ_LOG(LogApplication, Info, "Project Root set from environment variable: {0}",
                projectRoot.string());
         std::filesystem::path resourcesDir = projectRoot / "Resources";

--- a/xmake.lua
+++ b/xmake.lua
@@ -108,6 +108,18 @@ target("CopyFiles")
             cprint("${yellow}[CopyFiles]:${clear} Warning - imgui.ini not found at %s", config_src)
         end
 
+        local folders = {"Resources", "Shaders", "Config"}
+
+        for _, folder in ipairs(folders) do
+            local src = path.join(os.projectdir(), folder)
+            local dst = path.join(outdir, folder)
+            
+            if os.isdir(src) then
+                os.cp(src, outdir) 
+                cprint("${green}[CopyBinaries]:${clear} deploying folder %s", folder)
+            end
+        end
+
         for _, depname in ipairs(target:get("deps")) do
             local dep = project.target(depname)
             if dep then


### PR DESCRIPTION
- Enhance CopyFiles target to recursively deploy 'Shaders', 'Resources', and 'Config' directories to the output folder.
- Ensure the process working directory is switched to the executable path at startup to maintain VFS path integrity.